### PR TITLE
Raise minimum PHP version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "issues": "https://github.com/marijnvanwezel/try"
   },
   "require": {
-    "php": ">=7.4",
+    "php": "^8.0",
     "ext-pcntl": "*",
     "composer/composer": "^2.2",
     "psy/psysh": "^0.11.2"
@@ -29,9 +29,6 @@
     }
   },
   "config": {
-    "platform": {
-      "php": "8.0.0"
-    },
     "optimize-autoloader": true,
     "sort-packages": true
   },


### PR DESCRIPTION
It looks like you can't use a namespace component of "try" prior to PHP 7.4, so this package won't work without changing the namespace. (See simplified test cases at https://3v4l.org/fujss and https://3v4l.org/CS0R7). I've used `^8.0` rather than `>=8.0` so that it won't automatically claim compatibility with PHP 9.0, which might well have breaking changes.

I've also removed the "platform" configuration, as this is for [faking the PHP version at installation time](https://getcomposer.org/doc/06-config.md#platform) which is generally not a good idea.